### PR TITLE
チャンネル作成時に DB にチャンネル情報を挿入する機能を追加

### DIFF
--- a/skills/channel_created.js
+++ b/skills/channel_created.js
@@ -1,0 +1,13 @@
+const models = require('../models');
+
+module.exports = controller => {
+  controller.on('channel_created', async (bot, message) => {
+    const channel = message.channel;
+    await models.channel.create({
+      name: channel.name,
+      slackId: channel.id
+    }).catch(error => {
+      return error;
+    });
+  });
+};


### PR DESCRIPTION
## 概要/目的
チャンネル作成時に DB にチャンネル情報を挿入する機能を追加

## やったこと
channel_created.js を作成
channel_created イベントが発火されたら, チャンネル情報を DB に挿入する処理を追加

## 確認したこと
- [x] チャンネル作成時に, そのチャンネル情報が DB に新たに挿入されるか

## 備考
public チャンネルが作成されたときのみ, channel_created イベントが発火されるので, private channel は この処理では DB に追加できない.