### PR TITLE
team join イベントにユーザ情報を DB に挿入する処理を追加

### DIFF
--- a/skills/team_join.js
+++ b/skills/team_join.js
@@ -1,13 +1,34 @@
 const TeamJoinService = new (require('../worker_service/TeamJoinService.js'))();
+const models = require('../models');
+const { promisify } = require('util');
 
 module.exports = controller => {
-  controller.on('team_join', (bot, message) => {
+  controller.on('team_join', async (bot, message) => {
     bot.reply(message, 'Welcome, <@' + message.user + '>');
 
     const welcomeText = TeamJoinService.getWelcomeText();
     bot.say({
       text: welcomeText,
       channel: `${message.user}`
+    });
+
+
+    const user = await promisify(bot.api.users.info)({
+      token: process.env.AUTH_TOKEN,
+      user: message.user
+    }).catch(err => {
+      console.error(err);
+      return {};
+    });
+
+    const today = new Date();
+    models.user.create({
+      name: user.user.real_name,
+      slackId: user.user.id,
+      enrolledYear: today.getFullYear(),
+      disable: false,
+      created_at: today,
+      updated_at: today
     });
   });
 };


### PR DESCRIPTION
## 概要/目的
新しくチームに加入した人のユーザ情報を自動的に DB に挿入する機能を追加

## やったこと
team_join イベントにユーザ情報を users.info から取得し, DB に挿入する処理を追加

## 確認したこと
- [x] ユーザ情報が DB に挿入されているか

## 備考