### PR TITLE
レキサーに行末のドットを削除する処理を追加

### DIFF
--- a/worker_service/Lexer.js
+++ b/worker_service/Lexer.js
@@ -12,6 +12,7 @@ module.exports = class Lexer {
 
   lex() {
     const dividedUserMessage = this.formatString(this.userMessage)
+      .replace(/\.$/, '')
       .split(' ')
       .filter(value => value !== 'Reminder:' && value !== `<${BRAINS_BOT_ID}>`);
     const command  = dividedUserMessage[0].charAt(0).toUpperCase() + dividedUserMessage[0].slice(1);


### PR DESCRIPTION
## 概要/目的
slack bot の Reminder は行末にドットがつくため, それを削除するように変更

## やったこと
メッセージの行末からドットを削除する処理を追加

## 確認したこと
- [x] `brains get joinmessage.` が正しく動作するか

## 備考